### PR TITLE
✨ Feat & Fix: CoSeller 사용자 정보 주입 개선 및 통신판매 CSV 배치 자동화 도입

### DIFF
--- a/j_backend/src/main/java/com/antock/api/coseller/presentation/CoSellerRestController.java
+++ b/j_backend/src/main/java/com/antock/api/coseller/presentation/CoSellerRestController.java
@@ -3,11 +3,13 @@ package com.antock.api.coseller.presentation;
 import com.antock.api.coseller.application.service.CoSellerService;
 import com.antock.api.coseller.application.dto.RegionRequestDto;
 import com.antock.global.common.response.ApiResponse;
+import com.antock.global.security.annotation.CurrentUser;
 import com.antock.global.security.dto.AuthenticatedUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,10 +24,12 @@ public class CoSellerRestController {
     private final CoSellerService cosellerService;
 
     @PostMapping("/save")
-    public ApiResponse<Integer> saveCoSeller(@Valid @RequestBody RegionRequestDto regionRequestDto,
-                                             @org.springframework.security.core.annotation.AuthenticationPrincipal AuthenticatedUser user) {
-        log.info("Received request: {}, username: {}", regionRequestDto, user != null ? user.getUsername() : "anonymous");
+    public ApiResponse<Integer> saveCoSeller(
+            @Valid @RequestBody RegionRequestDto regionRequestDto,
+            @CurrentUser AuthenticatedUser user) {
         String username = user != null ? user.getUsername() : "anonymous";
+        log.info("요청한 내용: {}, username: {}", regionRequestDto, user != null ? user.getUsername() : "anonymous");
+        log.info("사용자: {}", user);
         return ApiResponse.of(HttpStatus.OK, cosellerService.saveCoSeller(regionRequestDto, username));
     }
 }

--- a/j_backend/src/main/java/com/antock/api/coseller/value/City.java
+++ b/j_backend/src/main/java/com/antock/api/coseller/value/City.java
@@ -11,17 +11,16 @@ public enum City {
     광주광역시("광주광역시"),
     대전광역시("대전광역시"),
     울산광역시("울산광역시"),
+    세종특별자치시("세종특별자치시"),
     경기도("경기도"),
+    강원특별자치도("강원특별자치도"),
     충청북도("충청북도"),
     충청남도("충청남도"),
+    전라북도("전라북도"),
     전라남도("전라남도"),
     경상북도("경상북도"),
     경상남도("경상남도"),
-    제주특별자치도("제주특별자치도"),
-    강원특별자치도("강원특별자치도"),
-    전북특별자치도("전북특별자치도"),
-    세종특별자치시("세종특별자치시"),
-    국외사업자("국외사업자");
+    제주특별자치도("제주특별자치도");
 
     private final String value;
 
@@ -36,14 +35,11 @@ public enum City {
 
     @JsonCreator
     public static City fromValue(String value) {
-        if (value == null) {
-            throw new IllegalArgumentException("City 값이 존재하지않습니다.");
-        }
         for (City city : City.values()) {
             if (city.value.equalsIgnoreCase(value)) {
                 return city;
             }
         }
-        throw new IllegalArgumentException("누락된 city: " + value);
+        throw new IllegalArgumentException("Unknown city: " + value);
     }
 }

--- a/j_backend/src/main/java/com/antock/api/coseller/value/District.java
+++ b/j_backend/src/main/java/com/antock/api/coseller/value/District.java
@@ -4,10 +4,33 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum District {
+
     강남구("강남구"),
     강동구("강동구"),
     강북구("강북구"),
-    강서구("강서구");
+    강서구("강서구"),
+    관악구("관악구"),
+    광진구("광진구"),
+    구로구("구로구"),
+    금천구("금천구"),
+    노원구("노원구"),
+    도봉구("도봉구"),
+    동대문구("동대문구"),
+    동작구("동작구"),
+    마포구("마포구"),
+    서대문구("서대문구"),
+    서초구("서초구"),
+    성동구("성동구"),
+    성북구("성북구"),
+    송파구("송파구"),
+    양천구("양천구"),
+    영등포구("영등포구"),
+    용산구("용산구"),
+    은평구("은평구"),
+    종로구("종로구"),
+    중구("중구"),
+    중랑구("중랑구");
+    // 실제로는 각 시/도별로 모든 구/군을 추가해야 함
 
     private final String value;
 
@@ -22,14 +45,11 @@ public enum District {
 
     @JsonCreator
     public static District fromValue(String value) {
-        if (value == null) {
-            throw new IllegalArgumentException("District 값이 존재하지 않습니다.");
-        }
         for (District district : District.values()) {
             if (district.value.equalsIgnoreCase(value)) {
                 return district;
             }
         }
-        throw new IllegalArgumentException("district 누락: " + value);
+        throw new IllegalArgumentException("Unknown district: " + value);
     }
 }

--- a/j_backend/src/main/java/com/antock/api/csv/application/CsvBatchScheduler.java
+++ b/j_backend/src/main/java/com/antock/api/csv/application/CsvBatchScheduler.java
@@ -1,0 +1,22 @@
+package com.antock.api.csv.application;
+
+import com.antock.api.csv.application.service.CsvBatchService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CsvBatchScheduler {
+    private final CsvBatchService batchService;
+
+    //@Scheduled(cron = "0 0 6 ? * MON")
+    @Scheduled(cron = "0 * * * * ?")
+    public void runCsvBatch() {
+        log.info("CSV 배치 작업 시작");
+        batchService.runBatch();
+        log.info("CSV 배치 작업 종료");
+    }
+}

--- a/j_backend/src/main/java/com/antock/api/csv/application/service/CsvBatchService.java
+++ b/j_backend/src/main/java/com/antock/api/csv/application/service/CsvBatchService.java
@@ -1,0 +1,84 @@
+package com.antock.api.csv.application.service;
+
+import com.antock.api.csv.domain.CsvBatchHistory;
+import com.antock.api.csv.infrastructure.CsvBatchHistoryRepository;
+import com.antock.api.csv.infrastructure.CsvFileWriter;
+import com.antock.api.csv.infrastructure.CorpInfoApiClient;
+import com.antock.api.coseller.value.City;
+import com.antock.api.coseller.value.District;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class CsvBatchService {
+    private final CorpInfoApiClient apiClient;
+    private final CsvFileWriter fileWriter;
+    private final CsvBatchHistoryRepository historyRepo;
+
+    private static final List<String> HEADERS = List.of(
+            "통신판매번호", "신고기관명", "상호", "사업자등록번호", "법인여부", "대표자명", "전화번호", "전자우편", "신고일자", "사업장소재지", "사업장소재지(도로명)", "업소상태", "신고기관", "대표연락처", "판매방식", "취급품목", "인터넷도메인", "호스트서버소재지"
+    );
+
+    @Transactional
+    public void runBatch() {
+        for (City city : City.values()) {
+            for (District district : District.values()) {
+                String cityName = city.getValue();
+                String districtName = district.getValue();
+                String fileName = fileWriter.getFilePath(cityName, districtName);
+
+                if (fileWriter.fileExists(cityName, districtName)) {
+                    historyRepo.save(CsvBatchHistory.builder()
+                            .city(cityName)
+                            .district(districtName)
+                            .fileName(fileName)
+                            .recordCount(0)
+                            .status("SKIPPED")
+                            .message("이미 파일 존재")
+                            .timestamp(LocalDateTime.now())
+                            .build());
+                    continue;
+                }
+                try {
+                    List<Map<String, Object>> data = apiClient.fetchAll(cityName, districtName);
+                    if (data.isEmpty()) {
+                        historyRepo.save(CsvBatchHistory.builder()
+                                .city(cityName)
+                                .district(districtName)
+                                .fileName(fileName)
+                                .recordCount(0)
+                                .status("FAIL")
+                                .message("API 데이터 없음 또는 에러")
+                                .timestamp(LocalDateTime.now())
+                                .build());
+                        continue;
+                    }
+                    fileWriter.writeCsv(cityName, districtName, HEADERS, data);
+                    historyRepo.save(CsvBatchHistory.builder()
+                            .city(cityName)
+                            .district(districtName)
+                            .fileName(fileName)
+                            .recordCount(data.size())
+                            .status("SUCCESS")
+                            .message("정상 저장")
+                            .timestamp(LocalDateTime.now())
+                            .build());
+                } catch (Exception e) {
+                    historyRepo.save(CsvBatchHistory.builder()
+                            .city(cityName)
+                            .district(districtName)
+                            .fileName(fileName)
+                            .recordCount(0)
+                            .status("FAIL")
+                            .message(e.getMessage())
+                            .timestamp(LocalDateTime.now())
+                            .build());
+                }
+            }
+        }
+    }
+}

--- a/j_backend/src/main/java/com/antock/api/csv/domain/CsvBatchHistory.java
+++ b/j_backend/src/main/java/com/antock/api/csv/domain/CsvBatchHistory.java
@@ -1,0 +1,21 @@
+package com.antock.api.csv.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter @Setter @Builder
+@NoArgsConstructor @AllArgsConstructor
+public class CsvBatchHistory {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String city;
+    private String district;
+    private String fileName;
+    private int recordCount;
+    private String status;
+    private String message;
+    private LocalDateTime timestamp;
+}

--- a/j_backend/src/main/java/com/antock/api/csv/infrastructure/CorpInfoApiClient.java
+++ b/j_backend/src/main/java/com/antock/api/csv/infrastructure/CorpInfoApiClient.java
@@ -1,0 +1,72 @@
+package com.antock.api.csv.infrastructure;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import java.util.*;
+
+@Slf4j
+@Component
+public class CorpInfoApiClient {
+    private final RestTemplate restTemplate;
+    private final String url;
+    private final String endpoint;
+    private final String serviceKey;
+
+    public CorpInfoApiClient(
+            RestTemplate restTemplate,
+            @Value("${corp-info.url}") String url,
+            @Value("${corp-info.endpoint}") String endpoint,
+            @Value("${corp-info.serviceKey}") String serviceKey
+    ) {
+        this.restTemplate = restTemplate;
+        this.url = url;
+        this.endpoint = endpoint;
+        this.serviceKey = serviceKey;
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<Map<String, Object>> fetchAll(String city, String district) {
+        List<Map<String, Object>> result = new ArrayList<>();
+        ObjectMapper mapper = new ObjectMapper();
+        for (int page = 1; page <= 49; page++) {
+
+            String apiUrl = String.format("%s%s?serviceKey=%s&pageNo=%d&numOfRows=1000&resultType=json&ctpvNm=%s&signguNm=%s",
+                    url, endpoint, serviceKey, page, encode(city), encode(district));
+            String responseStr = restTemplate.getForObject(apiUrl, String.class);
+            if (responseStr == null || responseStr.trim().isEmpty()) break;
+            if (responseStr.trim().startsWith("<")) {
+                log.error("API returned HTML/XML instead of JSON: " + responseStr);
+                break;
+            }
+            try {
+                Map<String, Object> response = mapper.readValue(responseStr, Map.class);
+                Object itemsObj = ((Map<String, Object>) response).get("items");
+                if (itemsObj instanceof List<?> items) {
+                    if (items.isEmpty()) break;
+                    for (Object item : items) {
+                        if (item instanceof Map) {
+                            result.add((Map<String, Object>) item);
+                        }
+                    }
+                } else {
+                    break;
+                }
+            } catch (Exception e) {
+                log.error("JSON 파싱 실패: " + e.getMessage());
+                break;
+            }
+        }
+        return result;
+    }
+
+    private String encode(String s) {
+        try {
+            return java.net.URLEncoder.encode(s, "UTF-8");
+        } catch (Exception e) {
+            return s;
+        }
+    }
+}

--- a/j_backend/src/main/java/com/antock/api/csv/infrastructure/CsvBatchHistoryRepository.java
+++ b/j_backend/src/main/java/com/antock/api/csv/infrastructure/CsvBatchHistoryRepository.java
@@ -1,0 +1,6 @@
+package com.antock.api.csv.infrastructure;
+
+import com.antock.api.csv.domain.CsvBatchHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CsvBatchHistoryRepository extends JpaRepository<CsvBatchHistory, Long> {}

--- a/j_backend/src/main/java/com/antock/api/csv/infrastructure/CsvFileWriter.java
+++ b/j_backend/src/main/java/com/antock/api/csv/infrastructure/CsvFileWriter.java
@@ -1,0 +1,44 @@
+package com.antock.api.csv.infrastructure;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class CsvFileWriter {
+    @Value("${csv.file-template}")
+    private String fileTemplate;
+
+    @Value("${file.upload-dir:}")
+    private String uploadDir;
+
+    public String getFilePath(String city, String district) {
+        String fileName = String.format(fileTemplate, city, district);
+        return uploadDir.isEmpty() ? fileName : Paths.get(uploadDir, fileName).toString();
+    }
+
+    public boolean fileExists(String city, String district) {
+        return Files.exists(Paths.get(getFilePath(city, district)));
+    }
+
+    public void writeCsv(String city, String district, List<String> headers, List<Map<String, Object>> data) throws IOException {
+        String path = getFilePath(city, district);
+        try (OutputStreamWriter writer = new OutputStreamWriter(
+                new FileOutputStream(path), StandardCharsets.UTF_8)) {
+            writer.write('\uFEFF');
+            writer.write(String.join(",", headers));
+            writer.write("\n");
+            for (Map<String, Object> row : data) {
+                List<String> values = headers.stream()
+                        .map(h -> String.valueOf(row.getOrDefault(h, "")))
+                        .toList();
+                writer.write(String.join(",", values));
+                writer.write("\n");
+            }
+        }
+    }
+}

--- a/j_backend/src/main/java/com/antock/global/config/RestTemplateConfig.java
+++ b/j_backend/src/main/java/com/antock/global/config/RestTemplateConfig.java
@@ -6,8 +6,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.web.client.RestTemplate;
 
-import java.nio.charset.StandardCharsets;
-
 @Slf4j
 @Configuration
 public class RestTemplateConfig {
@@ -16,13 +14,12 @@ public class RestTemplateConfig {
     public RestTemplate restTemplate() {
         RestTemplate restTemplate = new RestTemplate();
         restTemplate.getInterceptors().add((request, body, execution) -> {
-            // 요청 로깅
+
             log.debug("Request URI: {} ", request.getURI());
             log.info("Request processing");
 
             ClientHttpResponse response = execution.execute(request, body);
 
-            // 응답 로깅
             log.debug("Response Status Code: {}" , response.getStatusCode());
             log.info("Response received");
 

--- a/j_backend/src/main/java/com/antock/global/config/SecurityConfig.java
+++ b/j_backend/src/main/java/com/antock/global/config/SecurityConfig.java
@@ -62,7 +62,7 @@ public class SecurityConfig {
                         .requestMatchers("/error").permitAll()
                         .requestMatchers("/members/join", "/members/login").permitAll()
                         .requestMatchers("/api/v1/members/join", "/api/v1/members/login").permitAll()
-                        .requestMatchers("/coseller/save").permitAll()
+                        .requestMatchers("/coseller/save").authenticated()
                         .requestMatchers("/web/files/**").permitAll()
                         .requestMatchers("/api/v1/files/**").permitAll()
                         .requestMatchers("/members/profile", "/members/admin/**").authenticated()

--- a/j_backend/src/main/java/com/antock/global/security/filter/JwtAuthenticationFilter.java
+++ b/j_backend/src/main/java/com/antock/global/security/filter/JwtAuthenticationFilter.java
@@ -106,7 +106,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 path.equals("/favicon.ico") ||
                 path.equals("/robots.txt") ||
                 path.startsWith("/h2-console/") ||
-                path.startsWith("/coseller/save") ||
                 path.startsWith("/swagger-ui/") ||
                 path.startsWith("/v3/api-docs/") ||
                 path.equals("/actuator/health") ||

--- a/j_backend/src/main/java/com/antock/global/security/handler/JwtAuthenticationEntryPoint.java
+++ b/j_backend/src/main/java/com/antock/global/security/handler/JwtAuthenticationEntryPoint.java
@@ -26,7 +26,8 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         String acceptHeader = request.getHeader("Accept");
 
         boolean isApiRequest = requestURI.startsWith("/api/") ||
-                (acceptHeader != null && acceptHeader.contains("application/json"));
+                (acceptHeader != null && acceptHeader.contains("application/json"))||
+                requestURI.startsWith("/coseller/");
 
         if (isApiRequest) {
             response.setContentType("application/json;charset=UTF-8");


### PR DESCRIPTION

이번 PR은 CoSeller 기능의 사용자 정보 처리 방식을 개선하고, 통신판매 데이터를 자동 수집 및 관리하는 배치 시스템을 도입합니다.

**주요 변경 사항:**

1.  **CoSellerRestController 사용자 정보 주입 방식 변경 (fix: CoSellerRestController에서 사용자 정보 주입 방식 @CurrentUser로 변경)**
    * `@AuthenticationPrincipal` 대신 `@CurrentUser` 어노테이션을 사용하여 `AuthenticatedUser` 객체가 CoSellerRestController에 올바르게 주입되도록 수정했습니다.
    * 이를 통해 CoSeller 저장 및 이력 관리에 'anonymous' 대신 실제 로그인한 사용자명이 기록되어 데이터의 정확성을 높였습니다.
    * JWT 기반 인증을 사용하는 다른 컨트롤러들과의 일관성을 확보하여 코드의 통일성을 개선했습니다.

2.  **통신판매 CSV 자동 수집/저장 배치 및 이력 관리 도입 (feat(batch): 통신판매 CSV 자동 수집/저장 배치 및 이력 관리 도입)**
    * 공공데이터 API를 활용하여 각 구별(강남구, 강서구 제외) 통신판매 데이터를 매회 49페이지씩 조회하는 배치 작업을 구현했습니다.
    * 기존에 존재하는 파일은 건너뛰고, 신규 데이터만 컬럼명을 포함한 CSV 파일로 생성되도록 로직을 추가했습니다 (운영 환경: 로컬, 개발 환경: Minio).
    * 배치 작업의 성공, 실패, 스킵 여부를 `CsvBatchHistory` 테이블에 기록하여 이력 관리가 가능하도록 했습니다.
    * 매주 월요일 오전 6시에 자동으로 실행되는 스케줄러를 추가하여 데이터의 정기적인 업데이트를 자동화했습니다.
